### PR TITLE
gridworld/q-learning_ex(146p)에서 epsilon이 잘못 설정 되어 있습니다.  

### DIFF
--- a/1-grid-world/4-q-learning/agent.py
+++ b/1-grid-world/4-q-learning/agent.py
@@ -9,7 +9,7 @@ class QLearningAgent:
         self.actions = actions
         self.step_size = 0.01
         self.discount_factor = 0.9
-        self.epsilon = 0.9
+        self.epsilon = 0.1
         self.q_table = defaultdict(lambda: [0.0, 0.0, 0.0, 0.0])
 
     # <s, a, r, s'> 샘플로부터 큐함수 업데이트


### PR DESCRIPTION
gridworld/q-learning_ex(146p) 코드를 보면
epsilon이 0.9로 설정되어있고, numpy.random.rand()가 epsilon보다 작을 때, 무작위 행동을 반환합니다.

즉, '큐함수에 의한 행동반환' : '무작위 행동반환'이 1:9로 이루어져서 너무 많은 탐색을 시도합니다.
앞의 예제들은 epsilon이 0.1로 되어있네요. 해당 부분을 수정해서 풀리퀘드립니다.

책으로 공부 잘 하고 있습니다. 감사합니다^_^